### PR TITLE
Fix Vagrantfile heredoc termination

### DIFF
--- a/terraform/Vagrantfile
+++ b/terraform/Vagrantfile
@@ -68,7 +68,7 @@ Vagrant.configure("2") do |config|
 
       curl -sL "${IMAGEBUILDER_TARBALL_URI}" | tar xz ./image-builder
       sudo install -m 0755 image-builder /usr/local/bin/image-builder
-    EOF
+EOF
 
     echo "==> Provisioning complete."
   SHELL


### PR DESCRIPTION
## Summary
- fix indentation for EOF termination in `Vagrantfile`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684e73d6cbe4832e95738719bc4fd602