### PR TITLE
Fix nested heredoc call for image-builder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /.idea/
+.terraform/

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,0 +1,61 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/bmatcuk/vagrant" {
+  version     = "4.1.0"
+  constraints = "~> 4.0"
+  hashes = [
+    "h1:GtG/SA0Ga4uoqqokiwMiohNikFlt9opQotqXn9qGSDc=",
+    "zh:0bdeac3aee68bbb93f3328ff1a26d31aeb653da87b35b56159f33ef8162c4f81",
+    "zh:1b1aacc1ea02fc575da189a17356fe3da09d4137536ac983262c26902233aca4",
+    "zh:227707cf85c2a64be19864cc30d5293f89f368fbb9c4c90488eb230d832ef43d",
+    "zh:39904c3e1fbf8e5de416fa76d0404e1d731971c85c492511820270d8b1698238",
+    "zh:53681f2b3ab5b4bc5165cab44b0c8b5f2f09df3a3cc91312cd1557fcb83860ab",
+    "zh:54cf42666c946498d6669804286cb4befad129bfafefc53662ca819f07eed026",
+    "zh:6ad39376d706b2692dd1ada81032c95a9b41cb7b5a34c192eb4b94ae2e94cf1e",
+    "zh:742ffd7fc088742774237bb78b54537bd890176c36545c03c6126e1dc5685e72",
+    "zh:88f8d9976068b2fb1cee93aa29fc9e989504aaf320bbabda0e62728e9c9fc84a",
+    "zh:911e9a9b45998c1e67fdde6bcba37cfdb2f0a37d6424ce25bbee0a242b8670a8",
+    "zh:928ea7c0efc75a06cce4f9fdbdabbe6e0da3877cb28c158caeae05de8aabcce6",
+    "zh:948264d3a74e93a42db81177114698a137ea3f1e1ea2d5631683399e2b4f7bca",
+    "zh:e228f75269812ea4d2216b68b358c1f0b1624f96c780def491f55da268acc5fc",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/local" {
+  version = "2.5.3"
+  hashes = [
+    "h1:1Nkh16jQJMp0EuDmvP/96f5Unnir0z12WyDuoR6HjMo=",
+    "zh:284d4b5b572eacd456e605e94372f740f6de27b71b4e1fd49b63745d8ecd4927",
+    "zh:40d9dfc9c549e406b5aab73c023aa485633c1b6b730c933d7bcc2fa67fd1ae6e",
+    "zh:6243509bb208656eb9dc17d3c525c89acdd27f08def427a0dce22d5db90a4c8b",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:885d85869f927853b6fe330e235cd03c337ac3b933b0d9ae827ec32fa1fdcdbf",
+    "zh:bab66af51039bdfcccf85b25fe562cbba2f54f6b3812202f4873ade834ec201d",
+    "zh:c505ff1bf9442a889ac7dca3ac05a8ee6f852e0118dd9a61796a2f6ff4837f09",
+    "zh:d36c0b5770841ddb6eaf0499ba3de48e5d4fc99f4829b6ab66b0fab59b1aaf4f",
+    "zh:ddb6a407c7f3ec63efb4dad5f948b54f7f4434ee1a2607a49680d494b1776fe1",
+    "zh:e0dafdd4500bec23d3ff221e3a9b60621c5273e5df867bc59ef6b7e41f5c91f6",
+    "zh:ece8742fd2882a8fc9d6efd20e2590010d43db386b920b2a9c220cfecc18de47",
+    "zh:f4c6b3eb8f39105004cf720e202f04f57e3578441cfb76ca27611139bc116a82",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/null" {
+  version = "3.2.4"
+  hashes = [
+    "h1:hkf5w5B6q8e2A42ND2CjAvgvSN3puAosDmOJb3zCVQM=",
+    "zh:59f6b52ab4ff35739647f9509ee6d93d7c032985d9f8c6237d1f8a59471bbbe2",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:795c897119ff082133150121d39ff26cb5f89a730a2c8c26f3a9c1abf81a9c43",
+    "zh:7b9c7b16f118fbc2b05a983817b8ce2f86df125857966ad356353baf4bff5c0a",
+    "zh:85e33ab43e0e1726e5f97a874b8e24820b6565ff8076523cc2922ba671492991",
+    "zh:9d32ac3619cfc93eb3c4f423492a8e0f79db05fec58e449dee9b2d5873d5f69f",
+    "zh:9e15c3c9dd8e0d1e3731841d44c34571b6c97f5b95e8296a45318b94e5287a6e",
+    "zh:b4c2ab35d1b7696c30b64bf2c0f3a62329107bd1a9121ce70683dec58af19615",
+    "zh:c43723e8cc65bcdf5e0c92581dcbbdcbdcf18b8d2037406a5f2033b1e22de442",
+    "zh:ceb5495d9c31bfb299d246ab333f08c7fb0d67a4f82681fbf47f2a21c3e11ab5",
+    "zh:e171026b3659305c558d9804062762d168f50ba02b88b231d20ec99578a6233f",
+    "zh:ed0fe2acdb61330b01841fa790be00ec6beaac91d41f311fb8254f74eb6a711f",
+  ]
+}

--- a/terraform/Vagrantfile
+++ b/terraform/Vagrantfile
@@ -53,7 +53,7 @@ Vagrant.configure("2") do |config|
     su - image-builder -c "mkdir -p ~/.ssh && printf 'HostKeyAlgorithms +ssh-rsa\\nPubkeyAcceptedKeyTypes +ssh-rsa\\n' >> ~/.ssh/config && chmod 600 ~/.ssh/config"
 
     echo "==> Installing latest eks-a image-builder CLI"
-    su - image-builder -c <<'EOF'
+    su - image-builder -c "bash -s" <<'EOF'
       set -e
       export PATH=$PATH:/snap/bin           # ensure snap binaries are visible
       cd /tmp

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -24,7 +24,7 @@ resource "null_resource" "vagrant_reload" {
 
 resource "vagrant_vm" "eks_admin_vm" {
   name            = "eks-image-builder"
-  vagrantfile_dir = "${path.module}"
+  vagrantfile_dir = path.module
 
   # Pass VAGRANT_LOG=info to surface early errors in CI
   env = {


### PR DESCRIPTION
## Summary
- fix inline script for `su` command in Vagrantfile
- clean up terraform formatting
- add `.terraform.lock.hcl`
- ignore local terraform directories

## Testing
- `terraform fmt -check`
- `terraform validate`


------
https://chatgpt.com/codex/tasks/task_e_684e74e743d0832ea697048a318cd9b4